### PR TITLE
Add compilation options for robot_policy_state in README and CMakeLists

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,19 @@ Velocity Command:			/cmd_vel		(geometry_msgs::msg::Twist)
 ```
 
 
+### Compilation Options
+
+The `RobotState` struct in `protocol.hpp` contains a field `robot_policy_state` that is **enabled by default**. To disable it (for compatibility with older protocol versions), add the following flag when building:
+
+```bash
+colcon build --cmake-args -DENABLE_ROBOT_POLICY_STATE=OFF
+```
+
+Or modify the `CMakeLists.txt` option directly:
+```cmake
+set(ENABLE_ROBOT_POLICY_STATE OFF)
+```
+
 ### How to Use
 
 1. Open a new terminal and enter the following codes to **start the nodes** `jetson2motion`, `jetson2app`, `sensor_checker`:

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -33,6 +33,19 @@ IMU数据:			/imu/data		(sensor_msgs::msg::Imu)
 ```
 
 
+### 编译选项
+
+`protocol.hpp` 中 `RobotState` 结构体的 `robot_policy_state` 字段**默认启用**。如需禁用（兼容旧版本协议），编译时添加如下参数：
+
+```bash
+colcon build --cmake-args -DENABLE_ROBOT_POLICY_STATE=OFF
+```
+
+或直接在 `CMakeLists.txt` 中修改选项：
+```cmake
+set(ENABLE_ROBOT_POLICY_STATE OFF)
+```
+
 ### 使用方法
 
 1. 打开一个新的终端依次执行以下命令，以**启动通信功能包节点** `jetson2motion`, `jetson2app`, `sensor_checker`:

--- a/src/transfer/CMakeLists.txt
+++ b/src/transfer/CMakeLists.txt
@@ -12,6 +12,13 @@ endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g")
 
+# Option to enable robot_policy_state field in RobotState struct (for newer protocol versions)
+option(ENABLE_ROBOT_POLICY_STATE "Enable robot_policy_state field in RobotState" ON)
+if(ENABLE_ROBOT_POLICY_STATE)
+  add_compile_definitions(ENABLE_ROBOT_POLICY_STATE)
+  message(STATUS "robot_policy_state field enabled")
+endif()
+
 # find dependencies
 find_package(ament_cmake REQUIRED)
 find_package(rclcpp REQUIRED)

--- a/src/transfer/include/protocol.hpp
+++ b/src/transfer/include/protocol.hpp
@@ -29,7 +29,9 @@ struct ImuDataReceived{
 struct RobotState {
   int robot_basic_state;                 ///< Basic motion state of robot
   int robot_gait_state;
+#ifdef ENABLE_ROBOT_POLICY_STATE
   int robot_policy_state;                  ///< Robot gait information
+#endif
   double rpy[3];                         ///< IMU angular 
   double rpy_vel[3];                     ///< IMU angular velocity
   double xyz_acc[3];                     ///< IMU acceleration


### PR DESCRIPTION
The commit mentioned in #4 makes the ROS 2 package incompatible with legacy versions. Adding some documentation and options could improve it without misleading other developers